### PR TITLE
Fix ESLint error. Remove function name and async keyword

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'ndjson-readablestream' {
-  export default async function* myGenerator<T = any>(readableStream: ReadableStream): AsyncGenerator<T>;
+  export default function <T = any>(readableStream: ReadableStream): AsyncGenerator<T>;
 }


### PR DESCRIPTION
Ambient function signature should not be declared as generator (`*`) and don't need the `async` keyword

I also removed the "fake" function name (`myGenerator`) since the source returns an anonymous function.

[ESLint source](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/convert.ts#L1184)