### PR TITLE
Fix rollup-plugin-dts build error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'ndjson-readablestream' {
-  export default function <T = any>(readableStream: ReadableStream): AsyncGenerator<T>;
+  export default function readNDJSONStream<T = any>(readableStream: ReadableStream): AsyncGenerator<T>;
 }


### PR DESCRIPTION
`rollup-plugin-dts` does't support anonymous functions in `.d.ts` files.

This PR reintroduces the function name.