### PR TITLE
chore(test): Add unit test for multi-byte stream

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,13 +1,10 @@
 export default async function* (readableStream) {
-  const reader = readableStream.getReader();
+  const reader = readableStream.pipeThrough(new TextDecoderStream('utf-8')).getReader();
   let runningText = '';
-  let decoder = new TextDecoder('utf-8');
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
-    var text = decoder.decode(value, { stream: true });
-    const objects = text.split('\n');
-    for (const obj of objects) {
+    for (const obj of value.split('\n')) {
       try {
         runningText += obj;
         let result = JSON.parse(runningText);

--- a/index.test.js
+++ b/index.test.js
@@ -26,3 +26,33 @@ test('parses an NDJSON stream correctly', async () => {
   expect(results.length).toBe(2);
   expect(JSON.stringify(results)).toBe('[{"foo":"bar"},{"ｆｏｏ":"ｂａｒ"}]');
 });
+
+test('parses multi-byte characters', async () => {
+  const encoder = new TextEncoder();
+  const queue = [
+    encoder.encode('{"hello":"'),
+    new Uint8Array([240, 159]),
+    new Uint8Array([152, 131]),
+    encoder.encode('"}\n{}'),
+  ];
+  const stream = new ReadableStream({
+    pull(controller) {
+      const chunk = queue.shift();
+      if (chunk) {
+        controller.enqueue(chunk);
+      } else {
+        controller.close();
+      }
+    },
+    cancel() {},
+    type: 'bytes',
+  });
+
+  const results = [];
+  for await (const event of readNDJSONStream(stream)) {
+    results.push(event);
+  }
+
+  expect(results.length).toBe(2);
+  expect(JSON.stringify(results)).toBe('[{"hello":"😃"},{}]');
+});

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,7 +1,7 @@
 import { dts } from 'rollup-plugin-dts';
 import commonjs from '@rollup/plugin-commonjs';
 
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 export default [
   // browser-friendly UMD build


### PR DESCRIPTION
Hi @pamelafox! While reading the code I was a little confused by the `{stream: true}` option, and wasn't sure if it was going to correctly handle multi-byte strings split across stream chunks. I wrote up a unit test and (spoiler) I was wrong, it works just great already. But just in case you'd want that unit test included, here's a PR. 😅

Based on [this thread](https://github.com/whatwg/encoding/issues/184) streaming could be simplified a tiny bit (see changes in `index.mjs`) but again the unit test passes with or without that change.

Finally the `assert { type: 'json' };` syntax in `rollup.config.mjs` is no longer supported in recent Node.js versions, so I've included a fix for that (tested in Node.js v18, v20, v22, and v24).

Happy to remove any of these changes or split them into separate PRs if you'd prefer, as well!